### PR TITLE
Enhance frontend event-aware table management

### DIFF
--- a/frontend/src/components/PlayerList.tsx
+++ b/frontend/src/components/PlayerList.tsx
@@ -9,6 +9,7 @@ export default function PlayerList() {
   if (isLoading) return <div className="p-3 text-sm opacity-70">Loading players…</div>;
   if (error) return <div className="p-3 text-sm text-red-600">Failed to load players</div>;
 
+  const players = [...(data ?? [])].sort((a, b) => a.full_name.localeCompare(b.full_name));
   const isSelected = (p: Player) => selected.some((s) => s.id === p.id);
 
   return (
@@ -19,7 +20,7 @@ export default function PlayerList() {
       </div>
       <div className="rounded-xl border">
         <ul className="divide-y">
-          {data?.map((p) => (
+          {players.map((p) => (
             <li
               key={p.id}
               className={`px-3 py-2 cursor-pointer hover:bg-gray-50 flex items-center justify-between ${
@@ -28,7 +29,16 @@ export default function PlayerList() {
               onClick={() => toggle(p)}
             >
               <span className="truncate">{p.full_name}</span>
-              {isSelected(p) && <span className="text-xs rounded-full px-2 py-0.5 border">Selected</span>}
+              <span className="flex items-center gap-2">
+                {p.is_playing && (
+                  <span className="text-xs rounded-full bg-amber-100 text-amber-700 px-2 py-0.5">
+                    Playing
+                  </span>
+                )}
+                {isSelected(p) && (
+                  <span className="text-xs rounded-full px-2 py-0.5 border">Selected</span>
+                )}
+              </span>
             </li>
           ))}
         </ul>

--- a/frontend/src/hooks/useEvents.ts
+++ b/frontend/src/hooks/useEvents.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { EventEntity } from "@/types";
+
+export function useEvents() {
+  return useQuery({
+    queryKey: ["events"],
+    queryFn: () => api.get<EventEntity[]>("/events"),
+    staleTime: 30_000
+  });
+}

--- a/frontend/src/hooks/usePlayers.ts
+++ b/frontend/src/hooks/usePlayers.ts
@@ -2,8 +2,6 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import type { Player } from "@/types";
 
-
-
 function normalizePlayer(p: any): Player {
   const state = (p.state ?? p.status ?? "").toString().toLowerCase();
   return {
@@ -15,7 +13,7 @@ function normalizePlayer(p: any): Player {
       typeof p.is_playing === "boolean"
         ? p.is_playing
         : state
-        ? state === "playing" || state === "free" 
+        ? state === "playing"
         : undefined
   };
 }
@@ -23,7 +21,10 @@ function normalizePlayer(p: any): Player {
 export function usePlayers() {
   return useQuery({
     queryKey: ["players"],
-    queryFn: () => api.get<Player[]>("/players"),
+    queryFn: async () => {
+      const res = await api.get<unknown[]>("/players");
+      return res.map((p) => normalizePlayer(p)) as Player[];
+    },
     refetchInterval: 5000
   });
 }

--- a/frontend/src/hooks/useTables.ts
+++ b/frontend/src/hooks/useTables.ts
@@ -1,33 +1,48 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import type { TableEntity } from "@/types";
+import type { Player, TableEntity } from "@/types";
 
-export function useTables() {
+export function useTables(eventId?: string | number) {
   return useQuery({
-    queryKey: ["tables"],
-    queryFn: () => api.get<TableEntity[]>("/tables"),
+    queryKey: ["tables", eventId],
+    queryFn: () => {
+      if (!eventId) throw new Error("No active event selected");
+      return api.get<TableEntity[]>(`/events/${eventId}/tables/board`);
+    },
+    enabled: Boolean(eventId),
     refetchInterval: 5000
   });
 }
 
-export function useAssignPlayers() {
+export function useAssignPlayers(eventId?: string | number) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (vars: { tableId: TableEntity["id"]; playerIds: (string | number)[] }) =>
-      api.post<TableEntity>(`/tables/${vars.tableId}/assign`, { player_ids: vars.playerIds }),
+    mutationFn: async (vars: { tableId: TableEntity["id"]; players: [Player["id"], Player["id"]]; notify?: boolean }) => {
+      if (!eventId) throw new Error("No active event selected");
+      const [p1, p2] = vars.players;
+      return api.post<TableEntity>(`/events/${eventId}/tables/${vars.tableId}/assign`, {
+        player1_id: p1,
+        player2_id: p2,
+        notify: vars.notify ?? true
+      });
+    },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["tables"] });
+      qc.invalidateQueries({ queryKey: ["tables", eventId] });
+      qc.invalidateQueries({ queryKey: ["players"] });
     }
   });
 }
 
-export function useFreeTable() {
+export function useFreeTable(eventId?: string | number) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (vars: { tableId: TableEntity["id"] }) =>
-      api.post<TableEntity>(`/tables/${vars.tableId}/free`),
+    mutationFn: async (vars: { tableId: TableEntity["id"] }) => {
+      if (!eventId) throw new Error("No active event selected");
+      return api.post<TableEntity>(`/events/${eventId}/tables/${vars.tableId}/free`);
+    },
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["tables"] });
+      qc.invalidateQueries({ queryKey: ["tables", eventId] });
+      qc.invalidateQueries({ queryKey: ["players"] });
     }
   });
 }

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,33 +1,98 @@
+import { useEffect, useMemo } from "react";
 import PlayerList from "@/components/PlayerList";
+import { useEvents } from "@/hooks/useEvents";
 import { useTables } from "@/hooks/useTables";
 import TableCard from "@/components/TableCard";
+import { useEventStore } from "@/store/eventStore";
+import { useSelection } from "@/store/selectionStore";
 
 export default function MainPage() {
-  const { data, isLoading, error } = useTables();
+  const { data: events, isLoading: eventsLoading, error: eventsError } = useEvents();
+  const { activeEvent, setActiveEvent } = useEventStore();
+  const { clear } = useSelection();
+
+  useEffect(() => {
+    if (!activeEvent && events?.length) {
+      setActiveEvent(events[0]);
+    }
+  }, [events, activeEvent, setActiveEvent]);
+
+  useEffect(() => {
+    clear();
+  }, [activeEvent?.id, clear]);
+
+  const { data: tables, isLoading: tablesLoading, error: tablesError } = useTables(activeEvent?.id);
+
+  const eventOptions = useMemo(() => events ?? [], [events]);
+  const selectedEventId = activeEvent?.id?.toString() ?? "";
+  const noEvents = !eventsLoading && !eventsError && eventOptions.length === 0;
 
   return (
-    <div className="min-h-screen p-4 md:p-6">
-      <header className="mb-4 flex items-center justify-between">
-        <h1 className="text-xl font-semibold">PingPong Control</h1>
+    <div className="min-h-screen p-4 md:p-6 space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">PingPong Control</h1>
+          {activeEvent && (
+            <p className="text-sm opacity-70">
+              {activeEvent.location ? `${activeEvent.location} • ` : ""}
+              {activeEvent.tables_count} tables configured
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1 md:items-end">
+          <label className="text-xs uppercase tracking-wide opacity-70">Active event</label>
+          {eventsLoading ? (
+            <span className="text-sm opacity-70">Loading events…</span>
+          ) : eventsError ? (
+            <span className="text-sm text-red-600">Failed to load events</span>
+          ) : eventOptions.length ? (
+            <select
+              className="rounded-lg border px-3 py-1.5 text-sm bg-white"
+              value={selectedEventId}
+              onChange={(e) => {
+                const next = eventOptions.find((ev) => ev.id.toString() === e.target.value);
+                setActiveEvent(next);
+              }}
+            >
+              {eventOptions.map((ev) => (
+                <option key={ev.id} value={ev.id.toString()}>
+                  {ev.name}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span className="text-sm opacity-70">No events yet</span>
+          )}
+        </div>
       </header>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
         <aside className="md:col-span-1">
           <PlayerList />
         </aside>
 
-        <main className="md:col-span-2">
-          <div className="flex items-center justify-between mb-2">
+        <main className="md:col-span-2 space-y-3">
+          <div className="flex items-center justify-between">
             <h2 className="text-lg font-semibold">Tables</h2>
           </div>
 
-          {isLoading ? (
+          {noEvents ? (
+            <div className="p-3 text-sm opacity-70">Create an event to manage tables.</div>
+          ) : !activeEvent ? (
+            <div className="p-3 text-sm opacity-70">Select an event to see its tables.</div>
+          ) : tablesLoading ? (
             <div className="p-3 text-sm opacity-70">Loading tables…</div>
-          ) : error ? (
+          ) : tablesError ? (
             <div className="p-3 text-sm text-red-600">Failed to load tables</div>
           ) : (
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {data?.map((t) => <TableCard key={t.id} table={t} />)}
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {tables?.map((t) => (
+                <TableCard key={t.id} table={t} />
+              ))}
+              {!tables?.length && (
+                <div className="p-3 text-sm opacity-70">No tables configured for this event.</div>
+              )}
             </div>
           )}
         </main>

--- a/frontend/src/store/eventStore.ts
+++ b/frontend/src/store/eventStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import type { EventEntity } from "@/types";
+
+type EventState = {
+  activeEvent?: EventEntity;
+  setActiveEvent: (event?: EventEntity) => void;
+};
+
+export const useEventStore = create<EventState>((set) => ({
+  activeEvent: undefined,
+  setActiveEvent: (event) => set({ activeEvent: event })
+}));

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5,9 +5,27 @@ export type Player = {
   is_playing?: boolean;
 };
 
-export type TableEntity = {
+export type PlayerSlim = {
+  id: number | string;
+  full_name: string;
+  phone_number?: string | null;
+};
+
+export type EventEntity = {
   id: number | string;
   name: string;
-  is_free: boolean;
-  players: Player[];
+  tables_count: number;
+  starts_at?: string | null;
+  location?: string | null;
+};
+
+export type TableEntity = {
+  id: number | string;
+  event_id?: number | string;
+  status: string;
+  position?: number | null;
+  label?: string | null;
+  current_assignment_id?: number | null;
+  player1?: PlayerSlim | null;
+  player2?: PlayerSlim | null;
 };


### PR DESCRIPTION
## Summary
- add event selection state and query hooks to drive table requests
- update table cards to use event-aware mutations and show occupant info/errors
- polish player list sorting and status badges plus improved loading states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da8a39af48832c8073da0bc50be58f