### PR TITLE
refine event detail workflows

### DIFF
--- a/frontend/src/components/EventCollection.tsx
+++ b/frontend/src/components/EventCollection.tsx
@@ -22,12 +22,12 @@ type Props = {
 export default function EventCollection({ events, isLoading, error, selectedId, onSelect }: Props) {
   if (isLoading) {
     return (
-      <div className="space-y-3">
+      <div className="space-y-3 text-slate-200">
         <header className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Events</h2>
-          <span className="text-xs text-slate-500">Loading…</span>
+          <h2 className="text-lg font-semibold text-white">Events</h2>
+          <span className="text-xs text-slate-400">Loading…</span>
         </header>
-        <div className="rounded-xl border border-dashed border-slate-200 p-4 text-sm text-slate-500">
+        <div className="rounded-2xl border border-dashed border-slate-700/70 bg-slate-900/50 p-4 text-sm text-slate-400">
           Fetching events from the server.
         </div>
       </div>
@@ -37,13 +37,11 @@ export default function EventCollection({ events, isLoading, error, selectedId, 
   if (error) {
     const message = error instanceof Error ? error.message : "Failed to load events";
     return (
-      <div className="space-y-3">
+      <div className="space-y-3 text-slate-200">
         <header className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Events</h2>
+          <h2 className="text-lg font-semibold text-white">Events</h2>
         </header>
-        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-          {message}
-        </div>
+        <div className="rounded-2xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-200">{message}</div>
       </div>
     );
   }
@@ -51,17 +49,17 @@ export default function EventCollection({ events, isLoading, error, selectedId, 
   const items = events ?? [];
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4 text-slate-200">
       <header className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold">Events</h2>
-          <p className="text-xs text-slate-500">Select an event to manage its tables and roster.</p>
+          <h2 className="text-lg font-semibold text-white">Events</h2>
+          <p className="text-xs text-slate-400">Select an event to manage its tables and roster.</p>
         </div>
-        <span className="text-xs font-medium text-slate-500">{items.length} total</span>
+        <span className="text-xs font-medium text-slate-400">{items.length} total</span>
       </header>
 
       {items.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
+        <div className="rounded-2xl border border-dashed border-slate-700/70 bg-slate-900/50 p-6 text-center text-sm text-slate-400">
           No events yet. Use the form on the right to create your first event.
         </div>
       ) : (
@@ -74,23 +72,27 @@ export default function EventCollection({ events, isLoading, error, selectedId, 
                 <button
                   type="button"
                   onClick={() => onSelect(event)}
-                  className={`w-full rounded-2xl border px-4 py-3 text-left transition hover:-translate-y-0.5 hover:shadow-md ${
+                  className={`group w-full rounded-2xl border px-4 py-4 text-left transition focus:outline-none focus:ring-2 focus:ring-sky-400/60 focus:ring-offset-0 ${
                     isActive
-                      ? "border-slate-900 bg-slate-900 text-white shadow-lg"
-                      : "border-slate-200 bg-slate-50 text-slate-900"
+                      ? "border-sky-400/50 bg-sky-500/20 text-white shadow-[0_20px_45px_-25px_rgba(56,189,248,0.7)]"
+                      : "border-slate-800/70 bg-slate-950/70 text-slate-100 hover:border-sky-400/40 hover:bg-slate-900/70"
                   }`}
                 >
-                  <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-start justify-between gap-3">
                     <div>
                       <h3 className="text-base font-semibold">{event.name}</h3>
-                      {meta && <p className={`text-xs ${isActive ? "text-slate-200" : "text-slate-500"}`}>{meta}</p>}
+                      {meta && (
+                        <p className={`text-xs ${isActive ? "text-sky-100/90" : "text-slate-400"}`}>{meta}</p>
+                      )}
                     </div>
                     <span
-                      className={`rounded-full px-3 py-1 text-xs font-medium ${
-                        isActive ? "bg-white/20 text-white" : "bg-white text-slate-700"
+                      className={`rounded-full border px-3 py-1 text-xs font-medium transition ${
+                        isActive
+                          ? "border-white/30 bg-white/10 text-white"
+                          : "border-sky-400/30 bg-sky-500/10 text-sky-200 group-hover:border-sky-400/50"
                       }`}
                     >
-                      Activate
+                      {isActive ? "Active" : "Activate"}
                     </span>
                   </div>
                 </button>

--- a/frontend/src/components/EventPlayers.tsx
+++ b/frontend/src/components/EventPlayers.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useRemoveRegistration } from "@/hooks/useRegistrations";
+import { useSelection } from "@/store/selectionStore";
 import type { Registration } from "@/types";
 
 interface Props {
@@ -13,18 +14,24 @@ interface Props {
 export default function EventPlayers({ eventId, eventName, registrations, isLoading, error }: Props) {
   const removeRegistration = useRemoveRegistration(eventId);
   const [localError, setLocalError] = useState<string | null>(null);
+  const { selected, toggle } = useSelection();
 
   const roster = [...(registrations ?? [])].sort((a, b) =>
     a.player.full_name.localeCompare(b.player.full_name)
   );
 
   const busyId = removeRegistration.variables?.registrationId;
+  const isSelected = (playerId: Registration["player"]["id"]) =>
+    selected.some((item) => item.id.toString() === playerId.toString());
 
-  const handleRemove = async (registrationId: Registration["id"]) => {
+  const handleRemove = async (registration: Registration) => {
     if (!eventId) return;
     setLocalError(null);
     try {
-      await removeRegistration.mutateAsync({ registrationId });
+      await removeRegistration.mutateAsync({ registrationId: registration.id });
+      if (isSelected(registration.player.id)) {
+        toggle(registration.player);
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to remove player";
       setLocalError(message);
@@ -33,11 +40,11 @@ export default function EventPlayers({ eventId, eventName, registrations, isLoad
 
   if (!eventId) {
     return (
-      <div className="space-y-3">
+      <div className="space-y-3 text-slate-200">
         <header className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Event roster</h2>
+          <h2 className="text-lg font-semibold text-white">Event roster</h2>
         </header>
-        <div className="rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
+        <div className="rounded-2xl border border-dashed border-slate-700/60 bg-slate-900/50 p-6 text-center text-sm text-slate-400">
           Select an event to see its registered players.
         </div>
       </div>
@@ -46,15 +53,15 @@ export default function EventPlayers({ eventId, eventName, registrations, isLoad
 
   if (isLoading) {
     return (
-      <div className="space-y-3">
+      <div className="space-y-3 text-slate-200">
         <header className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold">Event roster</h2>
-            {eventName && <p className="text-xs text-slate-500">{eventName}</p>}
+            <h2 className="text-lg font-semibold text-white">Event roster</h2>
+            {eventName && <p className="text-xs text-slate-400">{eventName}</p>}
           </div>
-          <span className="text-xs text-slate-500">Loading…</span>
+          <span className="text-xs text-slate-400">Loading…</span>
         </header>
-        <div className="rounded-xl border border-dashed border-slate-200 p-4 text-sm text-slate-500">
+        <div className="rounded-2xl border border-dashed border-slate-700/60 bg-slate-900/50 p-4 text-sm text-slate-400">
           Fetching players registered for this event.
         </div>
       </div>
@@ -64,66 +71,88 @@ export default function EventPlayers({ eventId, eventName, registrations, isLoad
   if (error) {
     const message = error instanceof Error ? error.message : "Failed to load event players";
     return (
-      <div className="space-y-3">
+      <div className="space-y-3 text-slate-200">
         <header className="flex items-center justify-between">
           <div>
-            <h2 className="text-lg font-semibold">Event roster</h2>
-            {eventName && <p className="text-xs text-slate-500">{eventName}</p>}
+            <h2 className="text-lg font-semibold text-white">Event roster</h2>
+            {eventName && <p className="text-xs text-slate-400">{eventName}</p>}
           </div>
         </header>
-        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-          {message}
-        </div>
+        <div className="rounded-2xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-200">{message}</div>
       </div>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 text-slate-200">
       <header className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold">Event roster</h2>
-          {eventName && <p className="text-xs text-slate-500">Players registered for {eventName}</p>}
+          <h2 className="text-lg font-semibold text-white">Event roster</h2>
+          {eventName && <p className="text-xs text-slate-400">Players registered for {eventName}</p>}
         </div>
-        <span className="rounded-full bg-slate-900 px-3 py-1 text-xs font-semibold text-white">
+        <span className="rounded-full border border-sky-400/40 bg-sky-500/15 px-3 py-1 text-xs font-semibold text-sky-100">
           {roster.length} player{roster.length === 1 ? "" : "s"}
         </span>
       </header>
 
+      <p className="text-xs text-slate-400">
+        Click a player to queue them for table assignment, or remove them from the event if needed.
+      </p>
+
       {localError && (
-        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-          {localError}
-        </div>
+        <div className="rounded-md border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">{localError}</div>
       )}
 
       {roster.length === 0 ? (
-        <div className="rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
-          No players registered for this event yet. Use the forms below to add players from the list or
-          register new ones.
+        <div className="rounded-2xl border border-dashed border-slate-700/60 bg-slate-900/50 p-6 text-center text-sm text-slate-400">
+          No players registered for this event yet. Visit the dashboard to enroll players into this roster.
         </div>
       ) : (
-        <ul className="divide-y divide-slate-200 overflow-hidden rounded-xl border border-slate-200">
-          {roster.map((registration) => (
-            <li
-              key={registration.id}
-              className="flex flex-wrap items-center justify-between gap-3 bg-white/80 px-4 py-3"
-            >
-              <div>
-                <p className="text-sm font-medium text-slate-900">{registration.player.full_name}</p>
-                {registration.player.phone_number && (
-                  <p className="text-xs text-slate-500">{registration.player.phone_number}</p>
-                )}
-              </div>
-              <button
-                type="button"
-                onClick={() => handleRemove(registration.id)}
-                disabled={removeRegistration.isPending && busyId === registration.id}
-                className="rounded-lg border border-red-300 px-3 py-1 text-xs font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {removeRegistration.isPending && busyId === registration.id ? "Removing…" : "Remove"}
-              </button>
-            </li>
-          ))}
+        <ul className="space-y-3">
+          {roster.map((registration) => {
+            const player = registration.player;
+            const playerId = player.id;
+            const selectedState = isSelected(playerId);
+            return (
+              <li key={registration.id}>
+                <div
+                  className={`flex flex-wrap items-center gap-3 rounded-2xl border px-4 py-3 transition ${
+                    selectedState
+                      ? "border-sky-400/60 bg-sky-500/15 text-sky-100 shadow-[0_0_25px_rgba(56,189,248,0.2)]"
+                      : "border-slate-800/70 bg-slate-950/70"
+                  }`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => toggle(player)}
+                    className="flex flex-1 flex-col items-start gap-1 text-left text-sm"
+                    title={selectedState ? "Selected for table assignment" : "Click to select for table assignment"}
+                  >
+                    <span className="font-medium text-white">{player.full_name}</span>
+                    <span className="text-xs font-semibold uppercase tracking-wide text-sky-300">
+                      Player #{player.id}
+                    </span>
+                    {player.phone_number && <span className="text-xs text-slate-400">{player.phone_number}</span>}
+                  </button>
+                  <div className="flex items-center gap-2">
+                    {selectedState && (
+                      <span className="rounded-full border border-sky-400/60 bg-sky-500/25 px-2 py-0.5 text-xs font-semibold text-sky-100">
+                        Selected
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(registration)}
+                      disabled={removeRegistration.isPending && busyId === registration.id}
+                      className="rounded-lg border border-rose-300/40 bg-rose-500/10 px-3 py-1 text-xs font-medium text-rose-100 transition hover:border-rose-200/60 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {removeRegistration.isPending && busyId === registration.id ? "Removing…" : "Remove"}
+                    </button>
+                  </div>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/frontend/src/components/PlayerList.tsx
+++ b/frontend/src/components/PlayerList.tsx
@@ -6,44 +6,63 @@ export default function PlayerList() {
   const { data, isLoading, error } = usePlayers();
   const { selected, toggle } = useSelection();
 
-  if (isLoading) return <div className="p-3 text-sm opacity-70">Loading players…</div>;
-  if (error) return <div className="p-3 text-sm text-red-600">Failed to load players</div>;
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl border border-dashed border-slate-700/60 bg-slate-900/50 p-4 text-sm text-slate-400">
+        Loading players…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-200">
+        Failed to load players
+      </div>
+    );
+  }
 
   const players = [...(data ?? [])].sort((a, b) => a.full_name.localeCompare(b.full_name));
   const isSelected = (p: Player) => selected.some((s) => s.id === p.id);
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3 text-slate-200">
       <div className="flex items-center justify-between">
-        <h2 className="text-lg font-semibold">Players</h2>
-        <span className="text-xs opacity-70">{selected.length}/2 selected</span>
+        <h2 className="text-lg font-semibold text-white">Players</h2>
+        <span className="text-xs text-slate-400">{selected.length}/2 selected</span>
       </div>
-      <div className="rounded-xl border">
-        <ul className="divide-y">
+      <div className="overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-950/70">
+        <ul className="divide-y divide-slate-800/70">
           {players.map((p) => (
-            <li
-              key={p.id}
-              className={`px-3 py-2 cursor-pointer hover:bg-gray-50 flex items-center justify-between ${
-                isSelected(p) ? "bg-gray-100" : ""
-              }`}
-              onClick={() => toggle(p)}
-            >
-              <span className="truncate">{p.full_name}</span>
-              <span className="flex items-center gap-2">
-                {p.is_playing && (
-                  <span className="text-xs rounded-full bg-amber-100 text-amber-700 px-2 py-0.5">
-                    Playing
-                  </span>
-                )}
-                {isSelected(p) && (
-                  <span className="text-xs rounded-full px-2 py-0.5 border">Selected</span>
-                )}
-              </span>
+            <li key={p.id}>
+              <button
+                type="button"
+                className={`flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition focus:outline-none focus:ring-2 focus:ring-sky-400/60 focus:ring-offset-0 ${
+                  isSelected(p)
+                    ? "bg-sky-500/15 text-sky-100"
+                    : "text-slate-200 hover:bg-slate-900/70"
+                }`}
+                onClick={() => toggle(p)}
+              >
+                <span className="truncate">{p.full_name}</span>
+                <span className="flex items-center gap-2 text-xs">
+                  {p.is_playing && (
+                    <span className="rounded-full border border-amber-300/50 bg-amber-400/20 px-2 py-0.5 text-amber-100">
+                      Playing
+                    </span>
+                  )}
+                  {isSelected(p) && (
+                    <span className="rounded-full border border-sky-400/60 bg-sky-500/20 px-2 py-0.5 text-sky-100">
+                      Selected
+                    </span>
+                  )}
+                </span>
+              </button>
             </li>
           ))}
         </ul>
       </div>
-      <p className="text-xs opacity-70">Tip: select up to two players, then pick a table.</p>
+      <p className="text-xs text-slate-400">Tip: select up to two players, then pick a table.</p>
     </div>
   );
 }

--- a/frontend/src/components/TableCard.tsx
+++ b/frontend/src/components/TableCard.tsx
@@ -42,7 +42,7 @@ export default function TableCard({ table }: { table: TableEntity }) {
     try {
       await assign.mutateAsync({
         tableId: table.id,
-        players: [selected[0].id, selected[1].id],
+        players: [selected[0].id, selected[1].id]
       });
       clear();
     } catch (e) {
@@ -63,15 +63,17 @@ export default function TableCard({ table }: { table: TableEntity }) {
   };
 
   return (
-    <div className="flex h-full flex-col gap-4 rounded-2xl border border-slate-200 bg-slate-50/80 p-4 shadow-sm">
+    <div className="flex h-full flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/70 p-4 text-slate-200 shadow-[0_20px_45px_-30px_rgba(56,189,248,0.45)]">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <p className="text-xs uppercase tracking-wide text-slate-500">Table</p>
-          <h3 className="text-lg font-semibold text-slate-900">{label}</h3>
+          <p className="text-xs uppercase tracking-wide text-slate-400">Table</p>
+          <h3 className="text-lg font-semibold text-white">{label}</h3>
         </div>
         <span
-          className={`rounded-full px-3 py-1 text-xs font-semibold ${
-            isFree ? "bg-emerald-100 text-emerald-700" : "bg-rose-100 text-rose-700"
+          className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+            isFree
+              ? "border-emerald-300/50 bg-emerald-400/20 text-emerald-100"
+              : "border-rose-300/50 bg-rose-400/20 text-rose-100"
           }`}
         >
           {isFree ? "Free" : "Occupied"}
@@ -79,27 +81,27 @@ export default function TableCard({ table }: { table: TableEntity }) {
       </div>
 
       <div className="space-y-2 text-sm">
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Current match</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Current match</p>
         {players.length ? (
-          <div className="rounded-xl border border-slate-200 bg-white px-3 py-2">
-            <ul className="space-y-1 text-slate-700">
+          <div className="rounded-xl border border-slate-800/70 bg-slate-900/70 px-3 py-2">
+            <ul className="space-y-1 text-slate-200">
               {players.map((p) => (
                 <li key={p.id} className="flex items-center gap-2">
-                  <span className="inline-block h-2 w-2 rounded-full bg-slate-400" aria-hidden />
+                  <span className="inline-block h-2 w-2 rounded-full bg-sky-400" aria-hidden />
                   <span className="truncate">{p.full_name}</span>
                 </li>
               ))}
             </ul>
           </div>
         ) : (
-          <div className="rounded-xl border border-dashed border-slate-200 px-3 py-4 text-center text-xs text-slate-500">
+          <div className="rounded-xl border border-dashed border-slate-700/60 px-3 py-4 text-center text-xs text-slate-400">
             No players assigned.
           </div>
         )}
       </div>
 
       {errorMessage && (
-        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+        <div className="rounded-md border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
           {errorMessage}
         </div>
       )}
@@ -108,8 +110,10 @@ export default function TableCard({ table }: { table: TableEntity }) {
         <button
           disabled={!canAssign || busy}
           onClick={onAssign}
-          className={`flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition ${
-            canAssign && !busy ? "hover:bg-white" : "cursor-not-allowed opacity-50"
+          className={`flex-1 rounded-xl border px-3 py-2 text-sm font-medium transition ${
+            canAssign && !busy
+              ? "border-sky-400/60 bg-sky-500/20 text-white hover:border-sky-300"
+              : "cursor-not-allowed border-slate-800/60 bg-slate-900/60 text-slate-500"
           }`}
           title={assignTooltip}
         >
@@ -118,8 +122,10 @@ export default function TableCard({ table }: { table: TableEntity }) {
         <button
           disabled={!canFree || busy}
           onClick={onFree}
-          className={`flex-1 rounded-xl border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition ${
-            canFree && !busy ? "hover:bg-white" : "cursor-not-allowed opacity-50"
+          className={`flex-1 rounded-xl border px-3 py-2 text-sm font-medium transition ${
+            canFree && !busy
+              ? "border-slate-200/40 bg-slate-800/70 text-slate-100 hover:border-slate-100/60"
+              : "cursor-not-allowed border-slate-800/60 bg-slate-900/60 text-slate-500"
           }`}
           title={freeTooltip}
         >

--- a/frontend/src/pages/MainPage.tsx
+++ b/frontend/src/pages/MainPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import PlayerList from "@/components/PlayerList";
 import TableCard from "@/components/TableCard";
 import AdminActions from "@/components/AdminActions";
@@ -16,6 +16,7 @@ export default function MainPage() {
   const { activeEvent, setActiveEvent } = useEventStore();
   const { clear } = useSelection();
   const playersQuery = usePlayers();
+  const [activeView, setActiveView] = useState<"dashboard" | "event">("dashboard");
 
   useEffect(() => {
     if (!activeEvent && events?.length) {
@@ -27,13 +28,17 @@ export default function MainPage() {
     clear();
   }, [activeEvent?.id, clear]);
 
+  useEffect(() => {
+    if (!activeEvent) {
+      setActiveView("dashboard");
+    }
+  }, [activeEvent]);
+
   const { data: tables, isLoading: tablesLoading, error: tablesError } = useTables(activeEvent?.id);
   const registrationsQuery = useRegistrations(activeEvent?.id);
 
   const eventOptions = useMemo(() => events ?? [], [events]);
   const selectedEventId = activeEvent?.id?.toString() ?? "";
-  const noEvents = !eventsLoading && !eventsError && eventOptions.length === 0;
-
   const totalPlayers = playersQuery.data?.length ?? 0;
   const totalTables = tables?.length ?? 0;
   const occupiedTables = tables?.filter((table) => (table.status ?? "").toLowerCase() !== "free").length ?? 0;
@@ -72,26 +77,58 @@ export default function MainPage() {
     }
   ];
 
+  const renderTables = (emptyMessage: string) => {
+    if (tablesLoading) {
+      return (
+        <div className="rounded-xl border border-dashed border-slate-700/60 p-6 text-center text-sm text-slate-400">
+          Loading tables…
+        </div>
+      );
+    }
+
+    if (tablesError) {
+      return (
+        <div className="rounded-xl border border-rose-400/40 bg-rose-500/10 p-4 text-sm text-rose-200">
+          Failed to load tables
+        </div>
+      );
+    }
+
+    if (!tables?.length) {
+      return (
+        <div className="rounded-xl border border-dashed border-slate-700/60 p-6 text-center text-sm text-slate-400">
+          {emptyMessage}
+        </div>
+      );
+    }
+
+    return (
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        {tables.map((table) => (
+          <TableCard key={table.id} table={table} />
+        ))}
+      </div>
+    );
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
       <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-10 md:px-8">
         <header className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
           <div className="space-y-3">
-            <span className="text-xs font-semibold uppercase tracking-[0.35em] text-sky-300">Dashboard</span>
+            <span className="text-xs font-semibold uppercase tracking-[0.35em] text-sky-300">Control center</span>
             <h1 className="text-3xl font-semibold text-white md:text-4xl">PingPong Event Hub</h1>
             <p className="max-w-2xl text-sm text-slate-300">
               Coordinate tournaments, register players, and control tables from a single modern interface.
             </p>
           </div>
 
-          <div className="w-full max-w-sm rounded-3xl border border-white/10 bg-white/10 p-5 backdrop-blur">
+          <div className="w-full max-w-sm rounded-3xl border border-sky-400/20 bg-slate-900/70 p-5 shadow-[0_20px_60px_-35px_rgba(56,189,248,0.75)] backdrop-blur">
             <div className="flex flex-col gap-3">
               <div>
-                <label className="text-xs font-semibold uppercase tracking-wide text-slate-200">
-                  Active event
-                </label>
+                <label className="text-xs font-semibold uppercase tracking-wide text-slate-200">Active event</label>
                 {activeEvent ? (
-                  <div className="mt-2 rounded-2xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-slate-100">
+                  <div className="mt-2 rounded-2xl border border-sky-400/30 bg-slate-900/60 px-3 py-2 text-sm text-slate-100">
                     <p className="font-medium text-white">{activeEvent.name}</p>
                     <p className="text-xs text-slate-300">
                       {[activeEvent.location, `${activeEvent.tables_count} tables`].filter(Boolean).join(" • ")}
@@ -108,7 +145,7 @@ export default function MainPage() {
                 <span className="text-sm text-rose-200">Failed to load events</span>
               ) : eventOptions.length ? (
                 <select
-                  className="w-full rounded-xl border border-white/20 bg-slate-900/70 px-3 py-2 text-sm text-slate-100 focus:border-sky-300 focus:outline-none"
+                  className="w-full rounded-xl border border-sky-400/30 bg-slate-950/70 px-3 py-2 text-sm text-slate-100 focus:border-sky-300 focus:outline-none"
                   value={selectedEventId}
                   onChange={(e) => {
                     const next = eventOptions.find((ev) => ev.id.toString() === e.target.value);
@@ -128,94 +165,145 @@ export default function MainPage() {
           </div>
         </header>
 
-        <section className="grid gap-4 md:grid-cols-3">
-          {stats.map((stat) => (
-            <div
-              key={stat.label}
-              className="rounded-2xl border border-white/10 bg-white/10 p-5 backdrop-blur transition hover:border-sky-300/40"
+        <section className="flex flex-wrap items-center justify-between gap-4 rounded-3xl border border-sky-400/20 bg-slate-900/60 p-3 text-sm text-slate-200">
+          <div className="inline-flex overflow-hidden rounded-2xl border border-sky-400/30 bg-slate-950/60 p-1">
+            <button
+              type="button"
+              onClick={() => setActiveView("dashboard")}
+              className={`rounded-xl px-4 py-2 text-sm font-medium transition ${
+                activeView === "dashboard"
+                  ? "bg-sky-500/20 text-white shadow-[0_0_20px_rgba(56,189,248,0.35)]"
+                  : "text-slate-300 hover:text-white"
+              }`}
             >
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-200">{stat.label}</p>
-              <p className="mt-3 text-3xl font-semibold text-white">{stat.value}</p>
-              <p className="mt-2 text-xs text-slate-300">{stat.description}</p>
-            </div>
-          ))}
+              Dashboard
+            </button>
+            <button
+              type="button"
+              disabled={!activeEvent}
+              onClick={() => setActiveView("event")}
+              className={`rounded-xl px-4 py-2 text-sm font-medium transition ${
+                activeView === "event"
+                  ? "bg-sky-500/20 text-white shadow-[0_0_20px_rgba(56,189,248,0.35)]"
+                  : "text-slate-300 hover:text-white"
+              } ${!activeEvent ? "opacity-40" : ""}`}
+            >
+              Event detail
+            </button>
+          </div>
+
+          <p className="text-xs text-slate-400">
+            {activeView === "dashboard"
+              ? "View global stats, manage the roster, and prepare events."
+              : `Deep dive into ${activeEvent?.name ?? "your selected event"}.`}
+          </p>
         </section>
 
-        <div className="grid gap-6 lg:grid-cols-[320px_1fr] xl:grid-cols-[360px_1fr]">
-          <div className="space-y-6">
-            <div className="rounded-2xl bg-white p-5 shadow-xl">
-              <EventCollection
-                events={eventOptions}
-                isLoading={eventsLoading}
-                error={eventsError}
-                selectedId={activeEvent?.id}
-                onSelect={(event) => setActiveEvent(event)}
-              />
-            </div>
-
-            <div className="rounded-2xl bg-white p-5 shadow-xl">
-              <PlayerList />
-            </div>
-          </div>
-
-          <div className="space-y-6">
-            <div className="rounded-2xl bg-white p-5 shadow-xl">
-              <EventPlayers
-                eventId={activeEvent?.id}
-                eventName={activeEvent?.name}
-                registrations={registrationsQuery.data}
-                isLoading={registrationsQuery.isLoading}
-                error={registrationsQuery.error}
-              />
-            </div>
-
-            <div className="rounded-2xl bg-white p-5 shadow-xl">
-              <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                <div>
-                  <h2 className="text-xl font-semibold text-slate-900">Tables</h2>
-                  <p className="text-sm text-slate-500">Monitor occupancy and start matches.</p>
+        {activeView === "dashboard" ? (
+          <>
+            <section className="grid gap-4 md:grid-cols-3">
+              {stats.map((stat) => (
+                <div
+                  key={stat.label}
+                  className="rounded-2xl border border-sky-400/20 bg-slate-900/60 p-5 backdrop-blur transition hover:border-sky-300/40"
+                >
+                  <p className="text-xs font-semibold uppercase tracking-wide text-sky-200">{stat.label}</p>
+                  <p className="mt-3 text-3xl font-semibold text-white">{stat.value}</p>
+                  <p className="mt-2 text-xs text-slate-300">{stat.description}</p>
                 </div>
-                {activeEvent && (
-                  <div className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
-                    {tablesLoading ? "Updating…" : `${occupiedTables} occupied • ${freeTables} free`}
-                  </div>
-                )}
+              ))}
+            </section>
+
+            <div className="grid gap-6 lg:grid-cols-[340px_1fr] xl:grid-cols-[380px_1fr]">
+              <div className="space-y-6">
+                <div className="rounded-3xl border border-sky-400/20 bg-slate-950/70 p-6 shadow-[0_25px_70px_-40px_rgba(56,189,248,0.65)]">
+                  <EventCollection
+                    events={eventOptions}
+                    isLoading={eventsLoading}
+                    error={eventsError}
+                    selectedId={activeEvent?.id}
+                    onSelect={(event) => setActiveEvent(event)}
+                  />
+                </div>
+
+                <div className="rounded-3xl border border-sky-400/20 bg-slate-950/70 p-6 shadow-[0_25px_70px_-40px_rgba(56,189,248,0.65)]">
+                  <PlayerList />
+                </div>
               </div>
 
-              <div className="mt-4 space-y-4">
-                {noEvents ? (
-                  <div className="rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
-                    Create an event to manage tables.
-                  </div>
-                ) : !activeEvent ? (
-                  <div className="rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
-                    Select an event to see its tables.
-                  </div>
-                ) : tablesLoading ? (
-                  <div className="rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
-                    Loading tables…
-                  </div>
-                ) : tablesError ? (
-                  <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-                    Failed to load tables
-                  </div>
-                ) : tables && tables.length ? (
-                  <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                    {tables.map((table) => (
-                      <TableCard key={table.id} table={table} />
-                    ))}
-                  </div>
-                ) : (
-                  <div className="rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">
-                    No tables configured for this event yet. Use the tools below to add or generate tables.
-                  </div>
-                )}
+              <div className="space-y-6">
+                <div className="rounded-3xl border border-sky-400/20 bg-slate-950/70 p-6 shadow-[0_25px_70px_-40px_rgba(56,189,248,0.65)]">
+                  <EventPlayers
+                    eventId={activeEvent?.id}
+                    eventName={activeEvent?.name}
+                    registrations={registrationsQuery.data}
+                    isLoading={registrationsQuery.isLoading}
+                    error={registrationsQuery.error}
+                  />
+                </div>
+                <div className="rounded-3xl border border-sky-400/20 bg-slate-950/70 p-6 shadow-[0_25px_70px_-40px_rgba(56,189,248,0.65)]">
+                  <AdminActions tables={tables} registrations={registrationsQuery.data} />
+                </div>
               </div>
             </div>
+          </>
+        ) : (
+          <div className="space-y-8">
+            <section className="rounded-3xl border border-sky-400/30 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 shadow-[0_35px_90px_-45px_rgba(56,189,248,0.7)]">
+              <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-300">{activeEvent?.location || "Event"}</p>
+                  <h2 className="mt-2 text-3xl font-semibold text-white">{activeEvent?.name}</h2>
+                  <p className="mt-3 max-w-xl text-sm text-slate-300">
+                    Manage registrations, assign tables, and keep your matches running smoothly.
+                  </p>
+                </div>
+                <div className="flex flex-wrap items-center gap-3 text-sm text-slate-300">
+                  <span className="rounded-full border border-sky-400/40 bg-slate-900/70 px-3 py-1 text-xs font-semibold text-sky-200">
+                    {activeEvent?.tables_count ?? 0} table{(activeEvent?.tables_count ?? 0) === 1 ? "" : "s"}
+                  </span>
+                  <span className="rounded-full border border-sky-400/40 bg-slate-900/70 px-3 py-1 text-xs font-semibold text-sky-200">
+                    {registrationsQuery.isLoading ? "…" : `${rosterCount} player${rosterCount === 1 ? "" : "s"}`}
+                  </span>
+                </div>
+              </div>
+            </section>
 
-            <AdminActions tables={tables} />
+            <div className="grid gap-6 lg:grid-cols-[1.15fr_1fr]">
+              <div className="space-y-6">
+                <div className="rounded-3xl border border-sky-400/20 bg-slate-950/70 p-6 shadow-[0_25px_70px_-40px_rgba(56,189,248,0.65)]">
+                  <EventPlayers
+                    eventId={activeEvent?.id}
+                    eventName={activeEvent?.name}
+                    registrations={registrationsQuery.data}
+                    isLoading={registrationsQuery.isLoading}
+                    error={registrationsQuery.error}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-6">
+                <div className="rounded-3xl border border-sky-400/20 bg-slate-950/70 p-6 shadow-[0_25px_70px_-40px_rgba(56,189,248,0.65)]">
+                  <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <h3 className="text-xl font-semibold text-white">Tables</h3>
+                      <p className="text-sm text-slate-400">Assign players or free tables instantly.</p>
+                    </div>
+                    <div className="rounded-full border border-sky-400/40 bg-slate-900/70 px-3 py-1 text-xs font-semibold text-sky-200">
+                      {tablesLoading ? "Updating…" : `${occupiedTables} occupied • ${freeTables} free`}
+                    </div>
+                  </div>
+
+                  <div className="mt-4 space-y-4">
+                    {renderTables(
+                      "No tables configured for this event yet. Return to the dashboard to add or seed new tables."
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- keep the dual dashboard/event view while moving table management exclusively into the event detail screen
- refresh the roster experience with player numbers, selection for table assignments, and a focus on assignment/deassignment workflows
- filter event registration tools to hide enrolled players and add a bulk registration checklist for multi-adds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e52f47736c832cad8d2e5ce972753a